### PR TITLE
Build aarch64 linux wheels. 

### DIFF
--- a/.github/workflows/python-publish-cpp-cngi-template.yml
+++ b/.github/workflows/python-publish-cpp-cngi-template.yml
@@ -12,43 +12,43 @@ on:
 
 jobs:
   build-wheels:
-      name: Build wheels
-      runs-on: ${{ matrix.os }}
-      strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest, macos-15]
-      steps:
-        - uses: actions/checkout@v4
-        - name: Set up Python (driver, cibuildwheel installs its own Pythons)
-          uses: actions/setup-python@v5
-          with:
-            python-version: "3.11"
-        - name: Install cibuildwheel
-          run: python -m pip install --upgrade pip cibuildwheel==2.21.3
-        - name: Set up QEMU for aarch64 emulation
-          if: runner.os == 'Linux'
-          uses: docker/setup-qemu-action@v3
-          with:
-            platforms: arm64
-        - name: Show build matrix cibuildwheel sees
-          run: python -m cibuildwheel --print-build-identifiers
-        - name: Build wheels
-          env:
-            CIBW_BUILD: "cp311-* cp312-* cp313-*"
-            CIBW_ARCHS_LINUX: "x86_64 aarch64"
-            CIBW_SKIP: "*-musllinux_* *-manylinux_i686"
-            CIBW_ARCHS_MACOS: "arm64"
-            CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
-            CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
-            CIBW_TEST_COMMAND: "python -c \"import astroviper; print(dir(astroviper))\""
-          run: |
-            python -m cibuildwheel --output-dir wheelhouse
-        - name: Upload wheel artifacts
-          uses: actions/upload-artifact@v4
-          with:
-            name: wheels-${{ matrix.os }}
-            path: wheelhouse/*.whl
+    name: Build wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python (driver, cibuildwheel installs its own Pythons)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install cibuildwheel
+        run: python -m pip install --upgrade pip cibuildwheel==2.21.3
+      - name: Set up QEMU for aarch64 emulation
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Show build matrix cibuildwheel sees
+        run: python -m cibuildwheel --print-build-identifiers
+      - name: Build wheels
+        env:
+          CIBW_BUILD: "cp311-* cp312-* cp313-*"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_SKIP: "*-musllinux_* *-manylinux_i686"
+          CIBW_ARCHS_MACOS: "arm64"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
+          CIBW_TEST_COMMAND: "python -c \"import astroviper; print(dir(astroviper))\""
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
 
   build-sdist:
     name: Build sdist

--- a/.github/workflows/python-publish-cpp-cngi-template.yml
+++ b/.github/workflows/python-publish-cpp-cngi-template.yml
@@ -12,54 +12,43 @@ on:
 
 jobs:
   build-wheels:
-    name: Build wheels
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-15]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python (driver, cibuildwheel installs its own Pythons)
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install cibuildwheel
-        run: python -m pip install --upgrade pip cibuildwheel==2.21.3
-
-      - name: Show build matrix cibuildwheel sees
-        run: python -m cibuildwheel --print-build-identifiers
-
-      - name: Build wheels
-        env:
-          # Build CPython 3.11, 3.12, 3.13
-          CIBW_BUILD: "cp311-* cp312-* cp313-*"
-
-          # Only 64-bit Linux (avoid i686)
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_SKIP: "*-musllinux_* *-manylinux_i686"
-
-          # macOS: build only the runner's native arch (prevents duplicates)
-          # CIBW_ARCHS_MACOS: "native"
-          # macOS: pick arch based on runner
-          CIBW_ARCHS_MACOS: "arm64"
-
-          # Manylinux baseline for Linux wheels
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
-
-          # Optional quick import test
-          CIBW_TEST_COMMAND: "python -c \"import astroviper; print(dir(astroviper))\""
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.os }}
-          path: wheelhouse/*.whl
+      name: Build wheels
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest, macos-15]
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set up Python (driver, cibuildwheel installs its own Pythons)
+          uses: actions/setup-python@v5
+          with:
+            python-version: "3.11"
+        - name: Install cibuildwheel
+          run: python -m pip install --upgrade pip cibuildwheel==2.21.3
+        - name: Set up QEMU for aarch64 emulation
+          if: runner.os == 'Linux'
+          uses: docker/setup-qemu-action@v3
+          with:
+            platforms: arm64
+        - name: Show build matrix cibuildwheel sees
+          run: python -m cibuildwheel --print-build-identifiers
+        - name: Build wheels
+          env:
+            CIBW_BUILD: "cp311-* cp312-* cp313-*"
+            CIBW_ARCHS_LINUX: "x86_64 aarch64"
+            CIBW_SKIP: "*-musllinux_* *-manylinux_i686"
+            CIBW_ARCHS_MACOS: "arm64"
+            CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+            CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
+            CIBW_TEST_COMMAND: "python -c \"import astroviper; print(dir(astroviper))\""
+          run: |
+            python -m cibuildwheel --output-dir wheelhouse
+        - name: Upload wheel artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: wheels-${{ matrix.os }}
+            path: wheelhouse/*.whl
 
   build-sdist:
     name: Build sdist


### PR DESCRIPTION
For benchmarking at TACC we need aarch64 linux wheels of AStroVIPER.